### PR TITLE
Added `Set-WunderlistPermissionHeaders` and other styling changes

### DIFF
--- a/Wunderlist.psm1
+++ b/Wunderlist.psm1
@@ -6,18 +6,48 @@ $SUBTASK_URL = "a.wunderlist.com/api/v1/subtasks"
 $NOTE_URL = "a.wunderlist.com/api/v1/notes"
 $FILE_URL = "a.wunderlist.com/api/v1/files"
 
-function Get-WunderlistList
-{
-    Param(
-        [Parameter(Mandatory = $false, ValueFromPipeline = $false)]
-        [string] $Id,
+$script:permissionHeaders = $null
 
-        [Parameter(Mandatory = $true, ValueFromPipeline = $false)]
-        [hashtable] $PermissionHeaders
+function Set-WunderlistPermissionHeaders
+{
+    param(
+        [Parameter(Mandatory = $true, ValueFromPipeline = $false, ParameterSetName = "Table")]
+        [hashtable] $PermissionHeaders,
+
+        [Parameter(Mandatory = $true, ValueFromPipeline = $false, ParameterSetName = "Field")]
+        [string] $ClientId,
+        [Parameter(Mandatory = $true, ValueFromPipeline = $false, ParameterSetName = "Field")]
+        [string] $AccessToken
     )
 
-    EnsureKey -Object $PermissionHeaders -Key "X-Client-Id"
-    EnsureKey -Object $PermissionHeaders -Key "X-Access-Token"
+    switch ($PsCmdlet.ParameterSetName) {
+        "Table" {
+            EnsureKey -Object $PermissionHeaders -Key "ClientId"
+            EnsureKey -Object $PermissionHeaders -Key "AccessToken"
+
+            $script:permissionHeaders = @{
+                "X-Client-Id" = $PermissionHeaders["ClientId"]
+                "X-Access-Token" = $PermissionHeaders["AccessToken"]
+            }
+        }
+        "Field" {
+            $script:permissionHeaders = @{
+                "X-Client-Id" = $ClientId
+                "X-Access-Token" = $AccessToken
+            }
+        }}
+
+    Write-Output "Permission headers successfully set"
+}
+
+function Get-WunderlistList
+{
+    param(
+        [Parameter(Mandatory = $false, ValueFromPipeline = $false)]
+        [string] $Id
+    )
+
+    EnsurePermissionHeadersNotNull
 
     $listUrl = $LIST_URL
 
@@ -25,7 +55,7 @@ function Get-WunderlistList
         $listUrl = "$listUrl/$Id"
     }
 
-    $lists = TryInvokeWebRequest -Uri $listUrl -Headers $PermissionHeaders
+    $lists = TryInvokeWebRequest -Uri $listUrl -Headers $script:PermissionHeaders
     
     # Add additional properties to the return value for easy piping to get tasks
     $lists | ForEach-Object { Add-Member -InputObject $_ -NotePropertyName "ListId" -NotePropertyValue $_.id -PassThru }
@@ -33,42 +63,37 @@ function Get-WunderlistList
 
 function Get-WunderlistTask
 {
-    Param(
+    param(
         [Parameter(Mandatory = $true, ValueFromPipeline = $false, ParameterSetName = "Task")]
         [String] $Id,
 
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = "List")]
         [String] $ListId,
-
         [Parameter(Mandatory = $false, ValueFromPipelineByPropertyName = $true, ParameterSetName = "List")]
-        [switch] $IncludeCompleted,
-
-        [Parameter(Mandatory = $true, ValueFromPipeline = $false)]
-        [hashtable] $PermissionHeaders
+        [switch] $IncludeCompleted
     )
 
-    Begin {
-        EnsureKey -Object $PermissionHeaders -Key "X-Client-Id"
-        EnsureKey -Object $PermissionHeaders -Key "X-Access-Token"
+    begin {
+        EnsurePermissionHeadersNotNull
 
         $taskUrl = $TASK_URL
     }
 
 
-    Process {
+    process {
         switch ($PsCmdlet.ParameterSetName) {
             "Task" {
                 $taskUrl = "$taskUrl/$Id"
 
                 # Weird. Have to take a copy, else it acts as immutable for Add-Member
-                $temp = TryInvokeWebRequest -Uri $taskUrl -Headers $PermissionHeaders
+                $temp = TryInvokeWebRequest -Uri $taskUrl -Headers $script:PermissionHeaders
 
                 # Add additional properties to the return value for easy piping to get subtasks
                 $temp | ForEach-Object { Add-Member -InputObject $_ -NotePropertyName "TaskId" -NotePropertyValue $_.id -PassThru }
             }
             "List" {
                 # Weird. Have to take a copy, else it acts as immutable for Add-Member
-                $temp = TryInvokeWebRequest -Uri $taskUrl -Headers $PermissionHeaders -Body @{ "list_id" = $ListId }
+                $temp = TryInvokeWebRequest -Uri $taskUrl -Headers $script:PermissionHeaders -Body @{ "list_id" = $ListId }
 
                 # Add additional properties to the return value for easy piping to get subtasks
                 $temp | ForEach-Object { Add-Member -InputObject $_ -NotePropertyName "TaskId" -NotePropertyValue $_.id -PassThru }
@@ -77,7 +102,7 @@ function Get-WunderlistTask
                 #   IncludeCompleted switch will return everything including completed tasks
                 if ($IncludeCompleted) {
                     # Weird. Have to take a copy, else it acts as immutable for Add-Member
-                    $temp = TryInvokeWebRequest -Uri $taskUrl -Headers $PermissionHeaders -Body @{ "list_id" = $ListId; "completed" = $true }
+                    $temp = TryInvokeWebRequest -Uri $taskUrl -Headers $script:PermissionHeaders -Body @{ "list_id" = $ListId; "completed" = $true }
                    
                     # Add additional properties to the return value for easy piping to get subtasks
                     $temp | ForEach-Object { Add-Member -InputObject $_ -NotePropertyName "TaskId" -NotePropertyValue $_.id -PassThru }
@@ -89,7 +114,7 @@ function Get-WunderlistTask
 
 function Get-WunderlistSubTask
 {
-    Param(
+    param(
         [Parameter(Mandatory = $true, ValueFromPipeline = $false, ParameterSetName = "SubTask")]
         [String] $Id,
 
@@ -101,28 +126,24 @@ function Get-WunderlistSubTask
 
         [Parameter(Mandatory = $false, ValueFromPipeline = $false, ParameterSetName = "List")]
         [Parameter(ParameterSetName = "Task")]
-        [switch] $IncludeCompleted,
-
-        [Parameter(Mandatory = $true, ValueFromPipeline = $false)]
-        [hashtable] $PermissionHeaders
+        [switch] $IncludeCompleted
     )
 
-    Begin {
-        EnsureKey -Object $PermissionHeaders -Key "X-Client-Id"
-        EnsureKey -Object $PermissionHeaders -Key "X-Access-Token"
+    begin {
+        EnsurePermissionHeadersNotNull
 
         $subTaskUrl = $SUBTASK_URL
     }
 
-    Process {
+    process {
         switch ($PsCmdlet.ParameterSetName) {
             "SubTask" {
                 $subTaskUrl = "$subTaskUrl/$Id"
-                TryInvokeWebRequest -Uri $subTaskUrl -Headers $PermissionHeaders
+                TryInvokeWebRequest -Uri $subTaskUrl -Headers $script:PermissionHeaders
             }
             "Task" {
                 # Another bad\contradicting API design. Querying by task_id will return all subtasks including the completed ones!!
-                $subTasks = TryInvokeWebRequest -Uri $subTaskUrl -Headers $PermissionHeaders -Body @{ "task_id" = $TaskId }
+                $subTasks = TryInvokeWebRequest -Uri $subTaskUrl -Headers $script:PermissionHeaders -Body @{ "task_id" = $TaskId }
                 if ($IncludeCompleted) {
                     $subTasks
                 }
@@ -132,7 +153,7 @@ function Get-WunderlistSubTask
             }
             "List" {
                 # Another bad\contradicting API design. Querying by list_id will return all subtasks including the completed ones!!
-                $subTasks = TryInvokeWebRequest -Uri $subTaskUrl -Headers $PermissionHeaders -Body @{ "list_id" = $ListId }
+                $subTasks = TryInvokeWebRequest -Uri $subTaskUrl -Headers $script:PermissionHeaders -Body @{ "list_id" = $ListId }
                 if ($IncludeCompleted) {
                     $subTasks
                 }
@@ -154,30 +175,26 @@ function Get-WunderlistNote
         [String] $TaskId,
 
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = "List")]
-        [String] $ListId,
-
-        [Parameter(Mandatory = $true, ValueFromPipeline = $false)]
-        [hashtable] $PermissionHeaders
+        [String] $ListId
     )
 
-    Begin {
-        EnsureKey -Object $PermissionHeaders -Key "X-Client-Id"
-        EnsureKey -Object $PermissionHeaders -Key "X-Access-Token"
+    begin {
+        EnsurePermissionHeadersNotNull
 
         $noteUrl = $NOTE_URL
     }
 
-    Process {
+    process {
         switch ($PsCmdlet.ParameterSetName) {
             "Note" {
                 $noteUrl = "$noteUrl/$Id"
-                TryInvokeWebRequest -Uri $noteUrl -Headers $PermissionHeaders
+                TryInvokeWebRequest -Uri $noteUrl -Headers $script:PermissionHeaders
             }
             "Task" {
-                TryInvokeWebRequest -Uri $noteUrl -Headers $PermissionHeaders -Body @{ "task_id" = $TaskId }
+                TryInvokeWebRequest -Uri $noteUrl -Headers $script:PermissionHeaders -Body @{ "task_id" = $TaskId }
             }
             "List" {
-                TryInvokeWebRequest -Uri $noteUrl -Headers $PermissionHeaders -Body @{ "list_id" = $ListId }
+                TryInvokeWebRequest -Uri $noteUrl -Headers $script:PermissionHeaders -Body @{ "list_id" = $ListId }
             }
         }
     }
@@ -193,30 +210,26 @@ function Get-WunderlistFile
         [String] $TaskId,
 
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = "List")]
-        [String] $ListId,
-
-        [Parameter(Mandatory = $true, ValueFromPipeline = $false)]
-        [hashtable] $PermissionHeaders
+        [String] $ListId
     )
 
-    Begin {
-        EnsureKey -Object $PermissionHeaders -Key "X-Client-Id"
-        EnsureKey -Object $PermissionHeaders -Key "X-Access-Token"
+    begin {
+        EnsurePermissionHeadersNotNull
 
         $fileUrl = $FILE_URL
     }
 
-    Process {
+    process {
         switch ($PsCmdlet.ParameterSetName) {
             "File" {
                 $fileUrl = "$fileUrl/$Id"
-                TryInvokeWebRequest -Uri $fileUrl -Headers $PermissionHeaders
+                TryInvokeWebRequest -Uri $fileUrl -Headers $script:PermissionHeaders
             }
             "Task" {
-                TryInvokeWebRequest -Uri $fileUrl -Headers $PermissionHeaders -Body @{ "task_id" = $TaskId }
+                TryInvokeWebRequest -Uri $fileUrl -Headers $script:PermissionHeaders -Body @{ "task_id" = $TaskId }
             }
             "List" {
-                TryInvokeWebRequest -Uri $fileUrl -Headers $PermissionHeaders -Body @{ "list_id" = $ListId }
+                TryInvokeWebRequest -Uri $fileUrl -Headers $script:PermissionHeaders -Body @{ "list_id" = $ListId }
             }
         }
     }
@@ -224,7 +237,7 @@ function Get-WunderlistFile
 
 function EnsureKey
 {
-    Param(
+    param(
         [hashtable] $Object,
         [string] $Key
     )
@@ -238,9 +251,18 @@ function EnsureKey
     }
 }
 
+function EnsurePermissionHeadersNotNull
+{
+    if (-not $script:PermissionHeaders) {
+        throw "Permission header('X-Client-Id' or 'X-Access-Token') is null." + `
+                "Please call 'Set-PermissionHeaders' to set the appropriate permission headers(ClientId & AccessToken)." + `
+                "If you are not sure what this is about, please visit 'https://developer.wunderlist.com/' to register the app and obtain clientid and access token."
+    }
+}
+
 function TryInvokeWebRequest
 {
-    Param(
+    param(
         [string] $Uri,
         [hashtable] $Headers,
         [hashtable] $Body
@@ -251,7 +273,7 @@ function TryInvokeWebRequest
         
         $result.Content | ConvertFrom-Json
     }
-    catch [System.Net.WebException]{
+    catch [System.Net.WebException] {
         # Invoke-WebRequest throws regular WebExceptions with confusing text; hence casting to a much
         # useful text with this throw
         throw $_.Exception.Message + " " + $_.ErrorDetails
@@ -263,3 +285,5 @@ Export-ModuleMember -Function Get-WunderlistTask
 Export-ModuleMember -Function Get-WunderlistSubTask
 Export-ModuleMember -Function Get-WunderlistNote
 Export-ModuleMember -Function Get-WunderlistFile
+
+Export-ModuleMember -Function Set-WunderlistPermissionHeaders


### PR DESCRIPTION
- `Set-WunderlistPermissionHeaders` is now used to set permission headers for the module; this mitigates the requirement to pass permission headers to every API function call.
- Fixed styling